### PR TITLE
Add type to variables for compatibility with PHP7.3

### DIFF
--- a/Model/Rule/DataProvider.php
+++ b/Model/Rule/DataProvider.php
@@ -50,9 +50,9 @@ class DataProvider extends AbstractDataProvider
     /**
      * DataProvider constructor.
      *
-     * @param $name
-     * @param $primaryFieldName
-     * @param $requestFieldName
+     * @param string $name
+     * @param string $primaryFieldName
+     * @param string $requestFieldName
      * @param CollectionFactory $collectionFactory
      * @param ImageUploader     $imageUploader
      * @param Registry          $registry
@@ -60,9 +60,9 @@ class DataProvider extends AbstractDataProvider
      * @param array             $data
      */
     public function __construct(
-        $name,
-        $primaryFieldName,
-        $requestFieldName,
+        string $name,
+        string $primaryFieldName,
+        string $requestFieldName,
         CollectionFactory $collectionFactory,
         ImageUploader $imageUploader,
         Registry $registry,


### PR DESCRIPTION
The module won't compile in php 7.3 if we don't provide the variables type. Adding string will solve the issue (already tested).