### PR TITLE
Update boolfly_label_rule_listing.xml to fix duplication of admin grid

### DIFF
--- a/view/adminhtml/ui_component/boolfly_label_rule_listing.xml
+++ b/view/adminhtml/ui_component/boolfly_label_rule_listing.xml
@@ -33,7 +33,10 @@
             <argument name="requestFieldName" xsi:type="string">id</argument>
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
-                    <item name="update_url" xsi:type="url" path="mui/index/render"/>
+                    <item name="update_url" xsi:type="url" path="mui/index/render" />
+                    <item name="storageConfig" xsi:type="array">
+                        <item name="indexField" xsi:type="string">rule_id</item>
+                    </item>
                 </item>
             </argument>
         </argument>


### PR DESCRIPTION
Update boolfly_label_rule_listing.xml to fix duplication of admin grid